### PR TITLE
fix: use nodejs runtime for middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,5 +4,6 @@ import {routing} from './src/i18n/routing';
 export default createMiddleware(routing);
 
 export const config = {
-  matcher: '/((?!api|_next|_vercel|.*\\..*).*)'
+  matcher: '/((?!api|_next|_vercel|.*\\..*).*)',
+  runtime: 'nodejs'
 }; 


### PR DESCRIPTION
## Summary
- Next.js 16 deprecated edge runtime for middleware
- Switch to nodejs runtime to fix ReferenceError

## Issue
`ReferenceError: Cannot access 'nw' before initialization` when accessing the app

🤖 Generated with [Claude Code](https://claude.ai/code)